### PR TITLE
Mark repository as archived in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,11 @@
+[![FINOS - Archived](https://cdn.jsdelivr.net/gh/finos/contrib-toolbox@master/images/badge-archived.svg)](https://community.finos.org/docs/governance/lifecycle-stages/archived)
+
+> [!WARNING]
+> **This repository is archived and in a read-only state.**
+> You are welcome to download, clone, or fork this code, but please be aware that it is no longer actively maintained and may contain bugs or security vulnerabilities.
+>
+> **Interested in reviving this project?** If you would like to restore development activities, please contact the team at info@os-climate.org.
+
 # wri-gppd-ingestion-pipeline
 
 template for the team to use


### PR DESCRIPTION
Prepends the FINOS archived badge and read-only notice to the README as part of repository archival.

Signed-off-by: Juan Estrella <juan.estrella@finos.org>